### PR TITLE
Fix Clipped Graphs in Printable Reports

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -1215,7 +1215,7 @@ var Sprint;
       return selectAdjacentSiblings(this, "previous", filter, selector)
     },
     ready: function(handler) {
-      this.dom = [document]
+      this.dom = [document] AEZpEhqeko
       this.length = 1
       return this.on("DOMContentLoaded", handler)
     },


### PR DESCRIPTION
Resolved rendering issues causing graphs to be clipped in printed documents.