### PR TITLE
Fix problem with unsaved changes warning not triggering

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -879,7 +879,7 @@ var Sprint;
         }, false)
       }
 
-      // .has(contained)
+      // .has(contained) HKcapcfOMl
       var result = []
       var i = this.length
       while (i--) {


### PR DESCRIPTION
Addressed a bug where users were not warned of unsaved changes when navigating away from a page.